### PR TITLE
feat: Add formatting rules for when a string ends with a space and when new line is followed by a space

### DIFF
--- a/rules.py
+++ b/rules.py
@@ -49,6 +49,23 @@ class ExistenceRule(Rule):
         return explanation
 
 
+class EndsWithRule(Rule):
+    def __init__(self, sequence, custom_explanation=None, exception_ids=None):
+        super().__init__(exception_ids)
+        self.sequence = sequence.lower()
+        self.custom_explanation = custom_explanation
+
+    def is_matching(self, input_string):
+        return input_string.lower().endswith(self.sequence)
+
+    def get_explanation(self, string_value):
+        if self.custom_explanation is None:
+            explanation = f"ends with forbidden sequence [{self.sequence}]"
+        else:
+            explanation = f"ending [{self.sequence}] detected. {self.custom_explanation}"
+        return explanation
+
+
 class NoSpaceBeforeRule(ExistenceRule):
     def __init__(self, sequence, exception_ids=None):
         super().__init__(" " + sequence, f"found a forbidden space before [{sequence}]", exception_ids)

--- a/validator.py
+++ b/validator.py
@@ -1,4 +1,4 @@
-from .rules import ExistenceRule, FrenchEmailRule, NoSpaceBeforeRule, SpaceBeforeRule, SpaceBeforeColonRule
+from .rules import ExistenceRule, FrenchEmailRule, NoSpaceBeforeRule, SpaceBeforeRule, SpaceBeforeColonRule, EndsWithRule
 
 global_rules = [
     ExistenceRule("'", "Use the real apostrophe '’' instead", exception_ids=[
@@ -7,7 +7,9 @@ global_rules = [
     ]),
     ExistenceRule("...", "Use '…' so soft wrapping won't ever wrap text inbetween some of the dots"),
     ExistenceRule(r" \n", "No space before a new line"),
+    ExistenceRule(r"\n ", "No space after a new line"),
     ExistenceRule(r"\\n", "No escaped new line. You probably meant to add a real new line"),
+    EndsWithRule(r"\u0020", "No space at the end of a translation"),
 ]
 
 language_rules = {

--- a/validator.py
+++ b/validator.py
@@ -9,7 +9,10 @@ global_rules = [
     ExistenceRule(r" \n", "No space before a new line"),
     ExistenceRule(r"\n ", "No space after a new line"),
     ExistenceRule(r"\\n", "No escaped new line. You probably meant to add a real new line"),
-    EndsWithRule(r"\u0020", "No space at the end of a translation"),
+    # For Android because of the XML format that converts trailing spaces as the "\u0020" string of characters
+    EndsWithRule(r"\u0020", "A space at the end of a translation is an error most of the time"),
+    # For pretty much every other formats
+    EndsWithRule(" ", "A space at the end of a translation is an error most of the time"),
 ]
 
 language_rules = {


### PR DESCRIPTION
A space after a new line indicates that the following sentence will start with an unwanted leading space.

The ending space is almost always an error