### PR TITLE
feat: Add exception to a use case where an ending space in needed for drive

### DIFF
--- a/validator.py
+++ b/validator.py
@@ -10,9 +10,17 @@ global_rules = [
     ExistenceRule(r"\n ", "No space after a new line"),
     ExistenceRule(r"\\n", "No escaped new line. You probably meant to add a real new line"),
     # For Android because of the XML format that converts trailing spaces as the "\u0020" string of characters
-    EndsWithRule(r"\u0020", "A space at the end of a translation is an error most of the time"),
+    EndsWithRule(
+        r"\u0020",
+        "A space at the end of a translation is an error most of the time",
+        ["shareLinkPublicRightDescriptionPassword"],  # kDrive
+    ),
     # For pretty much every other formats
-    EndsWithRule(" ", "A space at the end of a translation is an error most of the time"),
+    EndsWithRule(
+        " ",
+        "A space at the end of a translation is an error most of the time",
+        ["shareLinkPublicRightDescriptionPassword"],  # kDrive
+    ),
 ]
 
 language_rules = {


### PR DESCRIPTION
These strings are concatenated optionally as placeholders inside of a bigger sting which makes it so we need to have the space inside of the string