### PR TITLE
feat: Add checks to verify consistency rules across all locales

### DIFF
--- a/rules.py
+++ b/rules.py
@@ -204,4 +204,4 @@ class ConsistentEndingRule(CrossLocaleRule):
         elif len(does_not) == 1:
             return f"inconsistent ending '{self.suffix}' only missing in '{does_not[0]}'"
         else:
-            return f"inconsistent ending '{self.suffix}' present in [{', '.join(ends_with)}] but missing in [{', '.join(does_not)}]"
+            return f"inconsistent ending '{self.suffix}' present in [{', '.join(ends_with)}] and missing in [{', '.join(does_not)}]"

--- a/rules.py
+++ b/rules.py
@@ -198,4 +198,10 @@ class ConsistentEndingRule(CrossLocaleRule):
     def get_explanation(self, translations):
         ends_with = sorted(locale for locale, value in translations.items() if value.endswith(self.suffix))
         does_not = sorted(locale for locale, value in translations.items() if not value.endswith(self.suffix))
-        return f"inconsistent ending '{self.suffix}' present in [{', '.join(ends_with)}] but missing in [{', '.join(does_not)}]"
+
+        if len(ends_with) == 1:
+            return f"inconsistent ending '{self.suffix}' only present in '{ends_with[0]}'"
+        elif len(does_not) == 1:
+            return f"inconsistent ending '{self.suffix}' only missing in '{does_not[0]}'"
+        else:
+            return f"inconsistent ending '{self.suffix}' present in [{', '.join(ends_with)}] but missing in [{', '.join(does_not)}]"

--- a/rules.py
+++ b/rules.py
@@ -140,3 +140,62 @@ class FrenchEmailRule(Rule):
 
     def get_explanation(self, string_value):
         return f"in french only '{self.reason}' is authorized"
+
+
+class CrossLocaleRule:
+    """Base class for rules that validate a key across all its locale translations at once."""
+
+    def __init__(self, exception_ids=None):
+        if exception_ids is None:
+            exception_ids = []
+
+        self.exception_ids = exception_ids
+
+    def check(self, string_id, translations):
+        """Check a key across all its translations.
+
+        Args:
+            string_id: The key identifier.
+            translations: A dict of {locale: value} for this key.
+
+        Returns:
+            True if the rule detected an error, False otherwise.
+        """
+        if string_id in self.exception_ids:
+            return False
+
+        is_matching = self.is_matching(translations)
+        if is_matching:
+            self.warn(string_id, translations)
+
+        return is_matching
+
+    def is_matching(self, translations):
+        """Return True if the translations violate the rule."""
+        raise NotImplementedError
+
+    def warn(self, string_id, translations):
+        header = get_string_id_header("all", string_id)
+        print(f"{header}{self.get_explanation(translations)}")
+
+    def get_explanation(self, translations):
+        raise NotImplementedError("CrossLocaleRule did not specify an explanation message")
+
+
+class ConsistentEndingRule(CrossLocaleRule):
+    """Ensures all translations of a key either all end with a given suffix or none do."""
+
+    def __init__(self, suffix, exception_ids=None):
+        super().__init__(exception_ids)
+        self.suffix = suffix
+
+    def is_matching(self, translations):
+        ends_with = {locale for locale, value in translations.items() if value.endswith(self.suffix)}
+        does_not = set(translations.keys()) - ends_with
+
+        return len(ends_with) > 0 and len(does_not) > 0
+
+    def get_explanation(self, translations):
+        ends_with = sorted(locale for locale, value in translations.items() if value.endswith(self.suffix))
+        does_not = sorted(locale for locale, value in translations.items() if not value.endswith(self.suffix))
+        return f"inconsistent ending '{self.suffix}' present in [{', '.join(ends_with)}] but missing in [{', '.join(does_not)}]"

--- a/validator.py
+++ b/validator.py
@@ -30,6 +30,7 @@ language_rules = {
         NoSpaceBeforeRule(":"),
         NoSpaceBeforeRule("?"),
         NoSpaceBeforeRule("!"),
+        ExistenceRule("color", "Use the british spelling 'colour'"),
     ],
     "fr": [
         FrenchEmailRule(exception_ids=[

--- a/validator.py
+++ b/validator.py
@@ -1,4 +1,5 @@
-from .rules import ExistenceRule, FrenchEmailRule, NoSpaceBeforeRule, SpaceBeforeRule, SpaceBeforeColonRule, EndsWithRule
+from .rules import ExistenceRule, FrenchEmailRule, NoSpaceBeforeRule, SpaceBeforeRule, SpaceBeforeColonRule, EndsWithRule, \
+    ConsistentEndingRule
 
 global_rules = [
     ExistenceRule("'", "Use the real apostrophe '’' instead", exception_ids=[
@@ -88,7 +89,8 @@ language_rules = {
     ],
     "el": [
         NoSpaceBeforeRule(":"),
-        NoSpaceBeforeRule(";"),
+        NoSpaceBeforeRule(";"),  # U+037E
+        NoSpaceBeforeRule(";"),  # Standard semicolon
         ExistenceRule("?", "In greek, the '?' is not used, instead they use a special unicode character U+037E ';'"),
         NoSpaceBeforeRule("!"),
     ],
@@ -128,6 +130,10 @@ language_rules = {
     ]
 }
 
+cross_locale_rules = [
+    ConsistentEndingRule("."),
+]
+
 
 def validate_string(language, name, value):
     error_count = 0
@@ -138,6 +144,25 @@ def validate_string(language, name, value):
 
     for language_rule in language_rules.get(language, []):
         if language_rule.check(value, language, name):
+            error_count += 1
+
+    return error_count
+
+
+def validate_key_across_locales(name, translations):
+    """Validate a key across all its locale translations.
+
+    Args:
+        name: The key identifier.
+        translations: A dict of {locale: value} for this key.
+
+    Returns:
+        The number of cross-locale rule violations for this key.
+    """
+    error_count = 0
+
+    for rule in cross_locale_rules:
+        if rule.check(name, translations):
             error_count += 1
 
     return error_count

--- a/validator.py
+++ b/validator.py
@@ -136,6 +136,7 @@ cross_locale_rules = [
         "onboardingExpirationSubtitleTemplate",  # SwissTransfer
         "sharedConflictDescription",  # kDrive
     ]),
+    ConsistentEndingRule("\\n"),
 ]
 
 

--- a/validator.py
+++ b/validator.py
@@ -1,5 +1,12 @@
-from .rules import ExistenceRule, FrenchEmailRule, NoSpaceBeforeRule, SpaceBeforeRule, SpaceBeforeColonRule, EndsWithRule, \
-    ConsistentEndingRule
+from .rules import (
+    ExistenceRule,
+    FrenchEmailRule,
+    NoSpaceBeforeRule,
+    SpaceBeforeRule,
+    SpaceBeforeColonRule,
+    EndsWithRule,
+    ConsistentEndingRule,
+)
 
 global_rules = [
     ExistenceRule("'", "Use the real apostrophe '’' instead", exception_ids=[

--- a/validator.py
+++ b/validator.py
@@ -134,6 +134,7 @@ cross_locale_rules = [
     ConsistentEndingRule(".", exception_ids=[
         "onboardingExpirationSubtitleArgument",  # SwissTransfer
         "onboardingExpirationSubtitleTemplate",  # SwissTransfer
+        "sharedConflictDescription",  # kDrive
     ]),
 ]
 

--- a/validator.py
+++ b/validator.py
@@ -131,7 +131,10 @@ language_rules = {
 }
 
 cross_locale_rules = [
-    ConsistentEndingRule("."),
+    ConsistentEndingRule(".", exception_ids=[
+        "onboardingExpirationSubtitleArgument",  # SwissTransfer
+        "onboardingExpirationSubtitleTemplate",  # SwissTransfer
+    ]),
 ]
 
 


### PR DESCRIPTION
Some rules like checking that all strings end in a coherent manner (always with a `.` or never with one) require a new type of Rule. This PR introduces CrossLocaleRule to solve this issue and adds the ConsistentEndingRule that extends it.

To enable this new functionality, on top of the old `validate_string()` there's now a new `validate_key_across_locales()` to accommodate for the new needs.