### PR TITLE
chore: Add exception

### DIFF
--- a/validator.py
+++ b/validator.py
@@ -53,6 +53,7 @@ language_rules = {
         SpaceBeforeColonRule(exception_ids=[
             "allDeletedFilePattern",  # kDrive
             "allLastModifiedFilePattern",  # kDrive
+            "liteSyncUnavailableDescription",  # kDrive desktop
         ]),
         SpaceBeforeRule("?"),
         SpaceBeforeRule("!"),


### PR DESCRIPTION
The string that causes an error represents a file path on the file system like D:/...