### PR TITLE
Add placeholder consistency rule

### DIFF
--- a/rules.py
+++ b/rules.py
@@ -207,24 +207,8 @@ class PlaceholderConsistencyRule(CrossLocaleRule):
         r"%%|%(?:\d+\$)?[+\-# 0]*\d*(?:\.\d+)?[hlLzjt]*[a-zA-Z@]"
     )
 
-    @classmethod
-    def _iter_placeholders(cls, value):
-        for match in cls.PLACEHOLDER_PATTERN.finditer(value or ""):
-            text = match.group(0)
-            if text == "%%":
-                continue
-            yield text
-
-    @classmethod
-    def _placeholders(cls, value):
-        return tuple(sorted(cls._iter_placeholders(value)))
-
-    @staticmethod
-    def _is_plural(value):
-        return isinstance(value, dict)
-
     def is_matching(self, translations):
-        plural_locales, plain_locales = self._partition(translations)
+        plural_locales, plain_locales = self._split_plurals_and_plain_strings(translations)
 
         # Mixed: some locales declare the key as a plural and others as a plain string.
         if plural_locales and plain_locales:
@@ -233,14 +217,14 @@ class PlaceholderConsistencyRule(CrossLocaleRule):
         if plural_locales:
             for form in self._collect_plural_forms(plural_locales):
                 form_translations = self._get_form_translations(plural_locales, form)
-                if len({self._placeholders(v) for v in form_translations.values()}) > 1:
+                if len({self._extract_placeholders(v) for v in form_translations.values()}) > 1:
                     return True
             return False
-
-        return len({self._placeholders(v) for v in plain_locales.values()}) > 1
+        else:
+            return len({self._extract_placeholders(v) for v in plain_locales.values()}) > 1
 
     def get_explanation(self, translations):
-        plural_locales, plain_locales = self._partition(translations)
+        plural_locales, plain_locales = self._split_plurals_and_plain_strings(translations)
 
         if plural_locales and plain_locales:
             plural = sorted(plural_locales.keys())
@@ -254,14 +238,31 @@ class PlaceholderConsistencyRule(CrossLocaleRule):
             messages = []
             for form in sorted(self._collect_plural_forms(plural_locales)):
                 form_translations = self._get_form_translations(plural_locales, form)
-                if len({self._placeholders(v) for v in form_translations.values()}) > 1:
+                if len({self._extract_placeholders(v) for v in form_translations.values()}) > 1:
                     messages.append(f"plural form '{form}': {self._format_groups(form_translations)}")
             return "inconsistent placeholders across locales for " + "; ".join(messages)
-
-        return f"inconsistent placeholders across locales: {self._format_groups(plain_locales)}"
+        else:
+            return f"inconsistent placeholders across locales: {self._format_groups(plain_locales)}"
 
     @classmethod
-    def _partition(cls, translations):
+    def _iter_placeholders(cls, value):
+        for match in cls.PLACEHOLDER_PATTERN.finditer(value or ""):
+            text = match.group(0)
+            if text == "%%":
+                continue
+            yield text
+
+    @classmethod
+    def _extract_placeholders(cls, value):
+        extracted_placeholders = sorted(cls._iter_placeholders(value))
+        return tuple(extracted_placeholders)
+
+    @staticmethod
+    def _is_plural(value):
+        return isinstance(value, dict)
+
+    @classmethod
+    def _split_plurals_and_plain_strings(cls, translations):
         """Split translations into (plural_locales, plain_locales) in a single pass."""
         plural_locales, plain_locales = {}, {}
         for locale, value in translations.items():
@@ -284,7 +285,7 @@ class PlaceholderConsistencyRule(CrossLocaleRule):
     def _format_groups(cls, translations):
         groups = {}
         for locale, value in translations.items():
-            groups.setdefault(cls._placeholders(value), []).append(locale)
+            groups.setdefault(cls._extract_placeholders(value), []).append(locale)
         parts = []
         for placeholders, locales in sorted(groups.items(), key=lambda item: sorted(item[1])):
             display = f"[{', '.join(placeholders)}]" if placeholders else "[]"

--- a/rules.py
+++ b/rules.py
@@ -185,6 +185,99 @@ class CrossLocaleRule:
         raise NotImplementedError("CrossLocaleRule did not specify an explanation message")
 
 
+class PlaceholderConsistencyRule(CrossLocaleRule):
+    """Ensures that all translations of a key use the same placeholders (e.g. %s, %d, %1$s, %@).
+
+    Plurals (when the value is a dict keyed by plural form like 'one', 'other', ...) are checked
+    per form across locales: different forms of the same plural may legitimately use different
+    placeholders, but a given form must be consistent across locales.
+    """
+
+    # Matches printf-style and Objective-C/Swift placeholders:
+    #   %s, %d, %i, %f, %x, %c, %@, with optional positional index (%1$s),
+    #   flags, width, precision and length modifiers (%-3.2f, %ld, ...).
+    # The `%%` alternative captures escaped percents so they aren't mistaken for placeholders.
+    PLACEHOLDER_PATTERN = re.compile(
+        r"%%|%(?:\d+\$)?[+\-# 0]*\d*(?:\.\d+)?[hlLzjt]*[a-zA-Z@]"
+    )
+
+    @classmethod
+    def _iter_placeholders(cls, value):
+        for match in cls.PLACEHOLDER_PATTERN.finditer(value or ""):
+            text = match.group(0)
+            if text == "%%":
+                continue
+            yield text
+
+    def _placeholders(self, value):
+        return tuple(sorted(self._iter_placeholders(value)))
+
+    @staticmethod
+    def _is_plural(value):
+        return isinstance(value, dict)
+
+    def is_matching(self, translations):
+        plural_locales = {locale: value for locale, value in translations.items() if self._is_plural(value)}
+        plain_locales = {locale: value for locale, value in translations.items() if not self._is_plural(value)}
+
+        # Mixed: some locales declare the key as a plural and others as a plain string.
+        if plural_locales and plain_locales:
+            return True
+
+        if plural_locales:
+            forms = set()
+            for value in plural_locales.values():
+                forms.update(value.keys())
+            for form in forms:
+                form_translations = {
+                    locale: value.get(form, "") for locale, value in plural_locales.items() if form in value
+                }
+                if len({self._placeholders(v) for v in form_translations.values()}) > 1:
+                    return True
+            return False
+
+        return len({self._placeholders(v) for v in plain_locales.values()}) > 1
+
+    def get_explanation(self, translations):
+        plural_locales = {locale: value for locale, value in translations.items() if self._is_plural(value)}
+        plain_locales = {locale: value for locale, value in translations.items() if not self._is_plural(value)}
+
+        if plural_locales and plain_locales:
+            plural = sorted(plural_locales.keys())
+            plain = sorted(plain_locales.keys())
+            return (
+                "inconsistent placeholders: key declared as a plural in "
+                f"[{', '.join(plural)}] but as a plain string in [{', '.join(plain)}]"
+            )
+
+        if plural_locales:
+            forms = set()
+            for value in plural_locales.values():
+                forms.update(value.keys())
+            messages = []
+            for form in sorted(forms):
+                form_translations = {
+                    locale: value.get(form, "") for locale, value in plural_locales.items() if form in value
+                }
+                if len({self._placeholders(v) for v in form_translations.values()}) > 1:
+                    messages.append(f"plural form '{form}': {self._format_groups(form_translations)}")
+            return "inconsistent placeholders across locales for " + "; ".join(messages)
+
+        return f"inconsistent placeholders across locales: {self._format_groups(plain_locales)}"
+
+    @staticmethod
+    def _format_groups(translations):
+        groups = {}
+        for locale, value in translations.items():
+            placeholders = tuple(sorted(PlaceholderConsistencyRule._iter_placeholders(value)))
+            groups.setdefault(placeholders, []).append(locale)
+        parts = []
+        for placeholders, locales in sorted(groups.items(), key=lambda item: sorted(item[1])):
+            display = f"[{', '.join(placeholders)}]" if placeholders else "[]"
+            parts.append(f"{display} in [{', '.join(sorted(locales))}]")
+        return ", ".join(parts)
+
+
 class ConsistentEndingRule(CrossLocaleRule):
     """Ensures all translations of a key either all end with a given suffix or none do."""
 

--- a/rules.py
+++ b/rules.py
@@ -193,10 +193,16 @@ class PlaceholderConsistencyRule(CrossLocaleRule):
     placeholders, but a given form must be consistent across locales.
     """
 
-    # Matches printf-style and Objective-C/Swift placeholders:
-    #   %s, %d, %i, %f, %x, %c, %@, with optional positional index (%1$s),
-    #   flags, width, precision and length modifiers (%-3.2f, %ld, ...).
-    # The `%%` alternative captures escaped percents so they aren't mistaken for placeholders.
+    # Matches printf-style and Objective-C/Swift placeholders, e.g. %s, %d, %i, %f, %x, %c, %@,
+    # %1$s, %2$d, %ld, %lld, %-3.2f, % d, %#x. Components, in order:
+    #   %                          literal percent sign
+    #   (?:\d+\$)?                 optional positional index, e.g. 1$ in %1$s
+    #   [+\-# 0]*                  optional flags (sign, alt form, padding, ...)
+    #   \d*                        optional minimum width
+    #   (?:\.\d+)?                 optional precision, e.g. .2 in %.2f
+    #   [hlLzjt]*                  optional length modifiers, e.g. l in %ld
+    #   [a-zA-Z@]                  conversion specifier (s, d, f, @, ...)
+    # The leading `%%` alternative captures escaped percents so they aren't mistaken for placeholders.
     PLACEHOLDER_PATTERN = re.compile(
         r"%%|%(?:\d+\$)?[+\-# 0]*\d*(?:\.\d+)?[hlLzjt]*[a-zA-Z@]"
     )
@@ -218,8 +224,7 @@ class PlaceholderConsistencyRule(CrossLocaleRule):
         return isinstance(value, dict)
 
     def is_matching(self, translations):
-        plural_locales = {locale: value for locale, value in translations.items() if self._is_plural(value)}
-        plain_locales = {locale: value for locale, value in translations.items() if not self._is_plural(value)}
+        plural_locales, plain_locales = self._partition(translations)
 
         # Mixed: some locales declare the key as a plural and others as a plain string.
         if plural_locales and plain_locales:
@@ -235,8 +240,7 @@ class PlaceholderConsistencyRule(CrossLocaleRule):
         return len({self._placeholders(v) for v in plain_locales.values()}) > 1
 
     def get_explanation(self, translations):
-        plural_locales = {locale: value for locale, value in translations.items() if self._is_plural(value)}
-        plain_locales = {locale: value for locale, value in translations.items() if not self._is_plural(value)}
+        plural_locales, plain_locales = self._partition(translations)
 
         if plural_locales and plain_locales:
             plural = sorted(plural_locales.keys())
@@ -255,6 +259,15 @@ class PlaceholderConsistencyRule(CrossLocaleRule):
             return "inconsistent placeholders across locales for " + "; ".join(messages)
 
         return f"inconsistent placeholders across locales: {self._format_groups(plain_locales)}"
+
+    @classmethod
+    def _partition(cls, translations):
+        """Split translations into (plural_locales, plain_locales) in a single pass."""
+        plural_locales, plain_locales = {}, {}
+        for locale, value in translations.items():
+            target = plural_locales if cls._is_plural(value) else plain_locales
+            target[locale] = value
+        return plural_locales, plain_locales
 
     @staticmethod
     def _collect_plural_forms(plural_locales):

--- a/rules.py
+++ b/rules.py
@@ -158,7 +158,8 @@ class CrossLocaleRule:
         """Check a key across all its translations.
 
         Args:
-            string_id: The key identifier.
+            string_id: The key identifier. If the original key was a plural, check will be called multiple times with a distinct
+                       string_id for each plural form.
             translations: A dict of {locale: value} for this key.
 
         Returns:
@@ -208,41 +209,10 @@ class PlaceholderConsistencyRule(CrossLocaleRule):
     )
 
     def is_matching(self, translations):
-        plural_locales, plain_locales = self._split_plurals_and_plain_strings(translations)
-
-        # Mixed: some locales declare the key as a plural and others as a plain string.
-        if plural_locales and plain_locales:
-            return True
-
-        if plural_locales:
-            for form in self._collect_plural_forms(plural_locales):
-                form_translations = self._get_form_translations(plural_locales, form)
-                if len({self._extract_placeholders(v) for v in form_translations.values()}) > 1:
-                    return True
-            return False
-        else:
-            return len({self._extract_placeholders(v) for v in plain_locales.values()}) > 1
+        return len({self._extract_placeholders(v) for v in translations.values()}) > 1
 
     def get_explanation(self, translations):
-        plural_locales, plain_locales = self._split_plurals_and_plain_strings(translations)
-
-        if plural_locales and plain_locales:
-            plural = sorted(plural_locales.keys())
-            plain = sorted(plain_locales.keys())
-            return (
-                "inconsistent placeholders: key declared as a plural in "
-                f"[{', '.join(plural)}] but as a plain string in [{', '.join(plain)}]"
-            )
-
-        if plural_locales:
-            messages = []
-            for form in sorted(self._collect_plural_forms(plural_locales)):
-                form_translations = self._get_form_translations(plural_locales, form)
-                if len({self._extract_placeholders(v) for v in form_translations.values()}) > 1:
-                    messages.append(f"plural form '{form}': {self._format_groups(form_translations)}")
-            return "inconsistent placeholders across locales for " + "; ".join(messages)
-        else:
-            return f"inconsistent placeholders across locales: {self._format_groups(plain_locales)}"
+        return f"inconsistent placeholders across locales: {self._format_groups(translations)}"
 
     @classmethod
     def _iter_placeholders(cls, value):
@@ -256,30 +226,6 @@ class PlaceholderConsistencyRule(CrossLocaleRule):
     def _extract_placeholders(cls, value):
         extracted_placeholders = sorted(cls._iter_placeholders(value))
         return tuple(extracted_placeholders)
-
-    @staticmethod
-    def _is_plural(value):
-        return isinstance(value, dict)
-
-    @classmethod
-    def _split_plurals_and_plain_strings(cls, translations):
-        """Split translations into (plural_locales, plain_locales) in a single pass."""
-        plural_locales, plain_locales = {}, {}
-        for locale, value in translations.items():
-            target = plural_locales if cls._is_plural(value) else plain_locales
-            target[locale] = value
-        return plural_locales, plain_locales
-
-    @staticmethod
-    def _collect_plural_forms(plural_locales):
-        forms = set()
-        for value in plural_locales.values():
-            forms.update(value.keys())
-        return forms
-
-    @staticmethod
-    def _get_form_translations(plural_locales, form):
-        return {locale: value[form] for locale, value in plural_locales.items() if form in value}
 
     @classmethod
     def _format_groups(cls, translations):

--- a/rules.py
+++ b/rules.py
@@ -209,8 +209,9 @@ class PlaceholderConsistencyRule(CrossLocaleRule):
                 continue
             yield text
 
-    def _placeholders(self, value):
-        return tuple(sorted(self._iter_placeholders(value)))
+    @classmethod
+    def _placeholders(cls, value):
+        return tuple(sorted(cls._iter_placeholders(value)))
 
     @staticmethod
     def _is_plural(value):
@@ -225,13 +226,8 @@ class PlaceholderConsistencyRule(CrossLocaleRule):
             return True
 
         if plural_locales:
-            forms = set()
-            for value in plural_locales.values():
-                forms.update(value.keys())
-            for form in forms:
-                form_translations = {
-                    locale: value.get(form, "") for locale, value in plural_locales.items() if form in value
-                }
+            for form in self._collect_plural_forms(plural_locales):
+                form_translations = self._get_form_translations(plural_locales, form)
                 if len({self._placeholders(v) for v in form_translations.values()}) > 1:
                     return True
             return False
@@ -251,14 +247,9 @@ class PlaceholderConsistencyRule(CrossLocaleRule):
             )
 
         if plural_locales:
-            forms = set()
-            for value in plural_locales.values():
-                forms.update(value.keys())
             messages = []
-            for form in sorted(forms):
-                form_translations = {
-                    locale: value.get(form, "") for locale, value in plural_locales.items() if form in value
-                }
+            for form in sorted(self._collect_plural_forms(plural_locales)):
+                form_translations = self._get_form_translations(plural_locales, form)
                 if len({self._placeholders(v) for v in form_translations.values()}) > 1:
                     messages.append(f"plural form '{form}': {self._format_groups(form_translations)}")
             return "inconsistent placeholders across locales for " + "; ".join(messages)
@@ -266,11 +257,21 @@ class PlaceholderConsistencyRule(CrossLocaleRule):
         return f"inconsistent placeholders across locales: {self._format_groups(plain_locales)}"
 
     @staticmethod
-    def _format_groups(translations):
+    def _collect_plural_forms(plural_locales):
+        forms = set()
+        for value in plural_locales.values():
+            forms.update(value.keys())
+        return forms
+
+    @staticmethod
+    def _get_form_translations(plural_locales, form):
+        return {locale: value[form] for locale, value in plural_locales.items() if form in value}
+
+    @classmethod
+    def _format_groups(cls, translations):
         groups = {}
         for locale, value in translations.items():
-            placeholders = tuple(sorted(PlaceholderConsistencyRule._iter_placeholders(value)))
-            groups.setdefault(placeholders, []).append(locale)
+            groups.setdefault(cls._placeholders(value), []).append(locale)
         parts = []
         for placeholders, locales in sorted(groups.items(), key=lambda item: sorted(item[1])):
             display = f"[{', '.join(placeholders)}]" if placeholders else "[]"

--- a/validator.py
+++ b/validator.py
@@ -6,6 +6,7 @@ from .rules import (
     SpaceBeforeColonRule,
     EndsWithRule,
     ConsistentEndingRule,
+    PlaceholderConsistencyRule,
 )
 
 global_rules = [
@@ -146,6 +147,7 @@ cross_locale_rules = [
         "sharedConflictDescription",  # kDrive
     ]),
     ConsistentEndingRule("\\n"),
+    PlaceholderConsistencyRule(),
 ]
 
 


### PR DESCRIPTION
Add a CrossLocaleRule rule to check that each translations of a given key have the same amount of place holders like %s, %d, %1$s, %2$d, %@, etc.

Differentiate between plain singular only strings and plural strings.  It's ok if one form of a plural has a different number of placeholders or even if they are of a different type than another form. What matters is that for a given plural form (one, other, etc.) the presence of placeholders is consistent across locales